### PR TITLE
Make it more clear root user should be used, and update setuptools version

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ## Usage
 
 ```
-# pkg install ccache llvm14 riscv64-none-elf-gcc python3 bison swig py38-setuptools
+# pkg install ccache llvm14 riscv64-none-elf-gcc python3 bison swig py39-setuptools
 # gmake
 # dd if=freebsd-d1.img of=/dev/mmc0
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 ## Usage
 
 ```
-pkg install ccache llvm14 riscv64-none-elf-gcc python3 bison swig py38-setuptools
-gmake
-dd if=freebsd-d1.img of=/dev/mmc0
+# pkg install ccache llvm14 riscv64-none-elf-gcc python3 bison swig py38-setuptools
+# gmake
+# dd if=freebsd-d1.img of=/dev/mmc0
 ```
 


### PR DESCRIPTION
Hi, thanks for this project! Had a great time trying it out on my MangoPi MQ-Pro. As a FreeBSD novice however, I first tried to `gmake` the image as a non-root user with `doas`. This caused some issues for me (I suspect because some env substitution caused $PWD to be empty). When building as the root user, which seems to be implied because of the `pkg install`, everything went smoothly.
I also noticed that the default python version on FreeBSD now seems to be 3.9. Because the setuptools for 3.8 have to be installed according to the wiki, this caused the build to fail on the first try. After installing the setuptools for 3.9, the build ran successfully.